### PR TITLE
Optimized bulk_update query by grouping similar values.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -5,6 +5,8 @@ The main QuerySet implementation. This provides the public API for the ORM.
 import copy
 import operator
 import warnings
+
+from collections import defaultdict
 from itertools import chain, islice
 
 from asgiref.sync import sync_to_async
@@ -898,12 +900,16 @@ class QuerySet(AltersData):
         for batch_objs in batches:
             update_kwargs = {}
             for field in fields:
-                when_statements = []
+                value_to_pks = defaultdict(list)
                 for obj in batch_objs:
                     attr = getattr(obj, field.attname)
                     if not hasattr(attr, "resolve_expression"):
                         attr = Value(attr, output_field=field)
-                    when_statements.append(When(pk=obj.pk, then=attr))
+                    value_to_pks[attr].append(obj.pk)
+                when_statements = [
+                    When(pk__in=ids, then=value)
+                    for value, ids in value_to_pks.items()
+                ]
                 case_statement = Case(*when_statements, output_field=field)
                 if requires_casting:
                     case_statement = Cast(case_statement, output_field=field)


### PR DESCRIPTION
Changed the query built in the bulk_update method to reduce the number of CASE WHEN statements generated.
This is done by grouping similar values together
in one IN statement.
This reduced the generated query size and
improved performance for shared field values.

**Trac ticket number**

N/A

#### Branch description
**Problem**:
  The original bulk_update generates redundant WHEN clauses for 
  fields with shared values. This increases query size and impacts 
  database performance.

**Solution**:
  Group objects by shared field values. Generate a single WHEN 
  clause per unique value using WHEN pk IN (pk1, pk2, ...) THEN value. 
  This reduces redundancy and improves efficiency.

**Example**:
Original SQL (inefficient):
```
UPDATE table_name
SET status = CASE
   WHEN pk = 1 THEN 'active'
   WHEN pk = 2 THEN 'inactive'
   WHEN pk = 3 THEN 'active'
   WHEN pk = 4 THEN 'inactive'
END
WHERE pk IN (1, 2, 3, 4);
```

Optimized SQL (efficient):
```
UPDATE table_name
SET status = CASE
   WHEN pk IN (1, 3) THEN 'active'
   WHEN pk IN (2, 4) THEN 'inactive'
END
WHERE pk IN (1, 2, 3, 4);
```

**Result**:
- Reduced query size
- Improved performance for common use cases.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
